### PR TITLE
Fix import so crypto-data builds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,3 @@
-import type {
-	IBatchRequestInput,
-	IDynoexprInput,
-	IDynoexprOutput,
-	ITransactRequestInput,
-} from "src/dynoexpr.d";
-
 import { getBatchExpressions, isBatchRequest } from "./operations/batch";
 import { getSingleTableExpressions } from "./operations/single";
 import {
@@ -12,6 +5,7 @@ import {
 	isTransactRequest,
 } from "./operations/transact";
 import { AwsSdkDocumentClient } from "./document-client";
+import { IBatchRequestInput, IDynoexprInput, IDynoexprOutput, ITransactRequestInput } from "./dynoexpr";
 
 interface IDynoexprArgs
 	extends IDynoexprInput,


### PR DESCRIPTION
# Description
Crypto-data goes boom without this:
```
node_modules/@tuplo/dynoexpr/dist/index.d.ts:1:97 - error TS2307: Cannot find module 'src/dynoexpr.d' or its corresponding type declarations.

1 import type { IBatchRequestInput, IDynoexprInput, IDynoexprOutput, ITransactRequestInput } from "src/dynoexpr.d";
                                                                                                  ~~~~~~~~~~~~~~~~

src/services/dynamo/DynamoQueryableService.ts:106:7 - error TS2345: Argument of type '{ Filter: QueryInputType<T>; KeyCondition: QueryInputType<T>; }' is not assignable to parameter of type 'Partial<IDynoexprArgs>'.
  Object literal may only specify known properties, and 'KeyCondition' does not exist in type 'Partial<IDynoexprArgs>'.

106       KeyCondition: keyConditionParams,
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/services/dynamo/DynamoQueryableService.ts:145:7 - error TS2345: Argument of type '{ Filter: QueryInputType<T>; }' is not assignable to parameter of type 'Partial<IDynoexprArgs>'.
  Object literal may only specify known properties, and 'Filter' does not exist in type 'Partial<IDynoexprArgs>'.

145       Filter: filterParams,
          ~~~~~~~~~~~~~~~~~~~~


Found 3 errors in 2 files.
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Manual 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
